### PR TITLE
feat: Add iPXE booting functionality

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+HOSTNAME=localhost

--- a/README.md
+++ b/README.md
@@ -69,12 +69,15 @@ The serve command starts an HTTP server that can be used to generate kickstarts 
 
 ```
 $ crispin serve -h
-usage: crispin serve [-h] -c COOKBOOK_DIR
+usage: crispin serve [-h] -c COOKBOOK_DIR -i IPXE_DIR
 
 options:
   -h, --help            show this help message and exit
   -c COOKBOOK_DIR, --cookbook-dir COOKBOOK_DIR
                         The path to the cookbook directory.
+  -i IPXE_DIR, --ipxe-dir IPXE_DIR
+                        The path to the directory containing vmlinuz and
+                        initrd.img.
 ```
 
 ### API
@@ -99,6 +102,17 @@ Example:
 
 ```
 curl -X POST -d '{"hostname": "my-new-host"}' http://localhost:9000/crispin/get/minimal-desktop
+```
+
+#### GET /ipxe/
+
+This endpoint serves an iPXE menu that can be used to boot and install a system using one of the kickstarts from the cookbook. The menu is generated at server startup based on the answer files in the cookbook.
+
+Example:
+
+```
+# in your iPXE script
+chain http://your-crispin-server:9000/ipxe/
 ```
 
 ## Debu

--- a/crispin/CrispinAPI.py
+++ b/crispin/CrispinAPI.py
@@ -16,7 +16,7 @@ def get_kickstart(answer_name, cookbook_dir):
     with open(answer_file, "r") as f:
         answers = json.load(f)
 
-    recipe_name = answers.get("metadata").get("recipe")
+    recipe_name = answers.get("recipe")
     if not recipe_name:
         raise ValueError("Recipe not specified in answers file")
 

--- a/crispin/CrispinIPXE.py
+++ b/crispin/CrispinIPXE.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+def generate_menu(cookbook_dir, hostname):
+    """
+    Generates an iPXE menu from the answer files in the cookbook.
+    """
+    answers_dir = Path(cookbook_dir) / "answers"
+    if not answers_dir.exists():
+        return "#!ipxe\necho No answer files found\nshell"
+
+    menu = "#!ipxe\n\n"
+    menu += "menu Crispin iPXE Boot Menu\n\n"
+
+    answer_files = sorted(list(answers_dir.glob("*.json")))
+    if not answer_files:
+        return "#!ipxe\necho No answer files found\nshell"
+
+    default_item = answer_files[0].stem
+    for answer_file in answer_files:
+        answer_name = answer_file.stem
+        menu += f"item {answer_name} {answer_name}\n"
+
+    menu += f"\nchoose --default {default_item} --timeout 5000 target && goto ${{target}}\n\n"
+
+    for answer_file in answer_files:
+        answer_name = answer_file.stem
+        menu += f":{answer_name}\n"
+        menu += f"kernel http://{hostname}:9000/vmlinuz inst.ks=http://{hostname}:9000/crispin/get/{answer_name} quiet\n"
+        menu += f"initrd http://{hostname}:9000/initrd.img\n"
+        menu += "boot\n"
+
+    return menu

--- a/crispin/crispin.py
+++ b/crispin/crispin.py
@@ -36,6 +36,13 @@ def main():
         help="The path to the cookbook directory.",
         required=True,
     )
+    serve_parser.add_argument(
+        "-i",
+        "--ipxe-dir",
+        type=str,
+        help="The path to the directory containing vmlinuz and initrd.img.",
+        required=True,
+    )
 
     generate_parser = subparser.add_parser(
         "generate", help="Set options for generating answers, kickstarts, and ISOs."
@@ -112,7 +119,7 @@ def main():
 
     if args.command == 'serve':
         from crispin.CrispinServe import run
-        run(cookbook_dir=args.cookbook_dir)
+        run(cookbook_dir=args.cookbook_dir, ipxe_dir=args.ipxe_dir)
         sys.exit(0)
 
     match args.verbose:

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(
     entry_points = {
         'console_scripts': ['crispin = crispin.crispin:main']
     },
-    install_requires = ['Jinja2>=3.1.3','MarkupSafe==2.1.3']
+    install_requires = ['Jinja2>=3.1.3','MarkupSafe==2.1.3', 'python-dotenv>=1.0.1']
 )


### PR DESCRIPTION
Adds the ability to serve an iPXE menu for automated kickstart installations.

- Implements a new `/ipxe/` endpoint that generates and serves an iPXE menu based on the answer files in the cookbook.
- Adds an `--ipxe-dir` argument to the `serve` command to specify the directory containing the `vmlinuz` and `initrd.img` files for iPXE booting.
- The server now loads a `.env` file to get the `HOSTNAME` for use in the iPXE menu URLs.
- Corrects the iPXE menu syntax and implements static file serving for the kernel and initrd.
- Updates the `README.md` to document the new iPXE functionality.